### PR TITLE
1.7.0-0.3.6 - Fix: Fiat Symbol UI Overflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-app",
-  "version": "1.7.0-0.3.5",
+  "version": "1.7.0-0.3.6",
   "scripts": {
     "dev": "vite dev",
     "dev-http": "vite dev --mode http",

--- a/src/lib/components/PaymentDetails.svelte
+++ b/src/lib/components/PaymentDetails.svelte
@@ -217,7 +217,7 @@
     {/if}
 
     <!-- DESCRIPTION -->
-    {#if payment.description}
+    {#if payment.description && !payment.offer?.description}
       <SummaryRow>
         <span slot="label">{$translate('app.labels.description')}:</span>
         <span slot="value">{payment.description}</span>

--- a/src/routes/channels/components/ChannelRow.svelte
+++ b/src/routes/channels/components/ChannelRow.svelte
@@ -35,9 +35,7 @@
     </div>
   </div>
 
-  <div
-  class:gap-x-1={localPercent && remotePercent}
-   class="flex items-center">
+  <div class:gap-x-1={localPercent && remotePercent} class="flex items-center">
     <div style="width: {localPercent}%;" class="h-2 rounded-full bg-purple-400" />
     <div style="width: {remotePercent}%;" class="h-2 rounded-full bg-purple-200" />
   </div>
@@ -46,7 +44,8 @@
     <div class="flex flex-col items-baseline">
       <div class="flex items-center font-semibold">
         <span
-          class="flex justify-center items-center -ml-1"
+          class="flex justify-center items-center"
+          class:-ml-1={primarySymbol.startsWith('<')}
           class:w-4={primarySymbol.startsWith('<')}
           class:mr-[2px]={!primarySymbol.startsWith('<')}>{@html primarySymbol}</span
         >
@@ -60,7 +59,9 @@
           commas: true
         })}
       </div>
-      <div class="text-xs dark:text-neutral-300 text-neutral-600">{$translate('app.labels.local')}</div>
+      <div class="text-xs dark:text-neutral-300 text-neutral-600">
+        {$translate('app.labels.local')}
+      </div>
     </div>
 
     <div class="flex flex-col items-end">
@@ -80,7 +81,9 @@
           commas: true
         })}
       </div>
-      <div class="text-xs dark:text-neutral-300 text-neutral-600">{$translate('app.labels.remote')}</div>
+      <div class="text-xs dark:text-neutral-300 text-neutral-600">
+        {$translate('app.labels.remote')}
+      </div>
     </div>
   </div>
 </a>


### PR DESCRIPTION
- Fixes negative margin covering fiat symbol in channel row
- Removes duplicate description on offer payment detail page