### PR TITLE
bolt11: correctly parse all valid bolt11 hrps

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -438,7 +438,7 @@ export function decodeBolt11(bolt11: string): (FormattedDecodedBolt11 & { bolt11
 }
 
 export const nodePublicKeyRegex = /[0-9a-fA-F]{66}/
-export const bolt11Regex = /^(lnbcrt|lnbc)[a-zA-HJ-NP-Z0-9]{1,}$/
+export const bolt11Regex = /^(lnbcrt|lnbc|lntbs|lntb)[a-zA-HJ-NP-Z0-9]{1,}$/
 const ipRegex = /^((25[0-5]|(2[0-4]|1\d|[1-9]|)\d)(\.(?!$)|$)){4}$/
 
 export function getPaymentDetails(destination: string, protocol = ''): ParsedBitcoinString {


### PR DESCRIPTION
untested, please merge.

	# Human-Readable Part

	The human-readable part of a Lightning invoice consists of two sections:
	1. `prefix`: `ln` + BIP-0173 currency prefix (e.g. `lnbc` for Bitcoin mainnet, `lntb` for Bitcoin testnet, `lntbs` for Bitcoin signet, and `lnbcrt` for Bitcoin regtest)

src: https://github.com/lightning/bolts/blob/master/11-payment-encoding.md#human-readable-part
Reported-By: @pocolocosv